### PR TITLE
MD5 detection regex fix

### DIFF
--- a/lib/PasswordLib/Password/Implementation/MD5.php
+++ b/lib/PasswordLib/Password/Implementation/MD5.php
@@ -43,7 +43,7 @@ class MD5 extends Crypt {
      * @return boolean Was the hash created by this method
      */
     public static function detect($hash) {
-        static $regex = '/^\$1\$[a-zA-Z0-9.\/]{12}\$[a-zA-Z0-9.\/]{22}/';
+        static $regex = '/^\$1\$[a-zA-Z0-9.\/]{8}\$[a-zA-Z0-9.\/]{22}/';
         return 1 == preg_match($regex, $hash);
     }
 


### PR DESCRIPTION
The salt portion of the hash is 12 characters inclusive of the opening/closing delimiters, so the regex should match 8 characters in the middle
