### PR TITLE
Fix sha alphabet

### DIFF
--- a/test/Unit/Password/Implementation/SHA256Test.php
+++ b/test/Unit/Password/Implementation/SHA256Test.php
@@ -26,9 +26,9 @@ class Unit_Password_Implementation_SHA256Test extends Unit_Password_Implementati
 
     public static function provideTestCreate() {
         return array(
-            array(1000, 'foo', SHA256::getPrefix() . 'rounds=1000$................$expjG7P4AN4svmCMHxzkAc.s8gNGp0fu4bYVVY8iQo1'),
-            array(1000, 'bar', SHA256::getPrefix() . 'rounds=1000$................$NYlBKYVTrvSD1CYbsBDngbAm7kyAJk/D9XX.3528r05'),
-            array(1000, 'baz', SHA256::getPrefix() . 'rounds=1000$................$sN32z5PIeyCOerA52tXRmNvbdcwPd/FqWAmZelaX9z6'),
+            array(1000, 'foo', SHA256::getPrefix() . "rounds=1000\$\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\$AaIctt3o2mZFLme8WGmPB4yQUd7uV7PT7spV8CJvXA1"),
+            array(1000, 'bar', SHA256::getPrefix() . "rounds=1000\$\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\$3MGN/aM/1YdTG3AV4IyJq5QEM6zNBDDaLh.rGS/nHI8"),
+            array(1000, 'baz', SHA256::getPrefix() . "rounds=1000\$\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\$BhLh/zh5GXbIIqmxFpzISUtZbRy9bhefHr9pc.4ri3A"),
         );
     }
 
@@ -149,7 +149,7 @@ class Unit_Password_Implementation_SHA256Test extends Unit_Password_Implementati
 
     protected function getSHA256MockInstance($iterations) {
         $gen = $this->getRandomGenerator(function($size) {
-            return str_repeat(chr(0), $size);
+            return str_repeat(chr(1), $size);
         });
         return new SHA256(array('rounds' => $iterations), $gen);
     }

--- a/test/Unit/Password/Implementation/SHA512Test.php
+++ b/test/Unit/Password/Implementation/SHA512Test.php
@@ -26,9 +26,9 @@ class Unit_Password_Implementation_SHA512Test extends Unit_Password_Implementati
 
     public static function provideTestCreate() {
         return array(
-            array(1000, 'foo', SHA512::getPrefix() . 'rounds=1000$................$DzEAWetj/cXAPD/tGmEgpqyosAIZjLaRQI5DKcZYKSGFbk.mGzvRkDy3skMGqnkS4jRvrFjObXjiv.i5Bnob41'),
-            array(1000, 'bar', SHA512::getPrefix() . 'rounds=1000$................$lKPnJbXtGAHAid5g7OPcHO3GZjaKv4osoaSPnNAq./mZ4dyGoq9IbAG8d9fcTJ1cxvEALMPki.mbzmNEHjY9b1'),
-            array(1000, 'baz', SHA512::getPrefix() . 'rounds=1000$................$WZTe6NH6a0MA4vcOjJ9nKZP2hLvr9GhPvYqlOargbJNpzQaluc5sEe.Ep/PF2D79haaMPsFRGsnA2YEW3d7wx1'),
+            array(1000, 'foo', SHA512::getPrefix() . "rounds=1000\$\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\$5yUq/cJAngIZ0sWBdbZ50jTCUDrMwA08nvnCWUiaCsi6PEuPaUoY8K7MS8IbLj8uE640rjnIF84x1ayZ5UDbq/"),
+            array(1000, 'bar', SHA512::getPrefix() . "rounds=1000\$\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\$CtKbNszU3gfdh4/aF/V5RNT2a8qljIs9JTINsFConxEvFO3ubFxUqojuOzxCPtqNtdkko/CYO3IGaiAn7ZxE20"),
+            array(1000, 'baz', SHA512::getPrefix() . "rounds=1000\$\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\1\$O6m4HWAD6AJo9oSPerzqDlBtGYQytvvtdz98lDwjxOmnlmZodLgtntMYN5l45qfWX54CqDJeS6AGQwXRh2/Ap."),
         );
     }
 
@@ -150,7 +150,7 @@ class Unit_Password_Implementation_SHA512Test extends Unit_Password_Implementati
 
     protected function getSHA512MockInstance($iterations) {
         $gen = $this->getRandomGenerator(function($size) {
-            return str_repeat(chr(0), $size);
+            return str_repeat(chr(1), $size);
         });
         return new SHA512(array('rounds' => $iterations), $gen);
     }


### PR DESCRIPTION
Unix crypt SHA256/SHA512 are using the wrong alphabet for salts.

First some changes to the tests to show that the current implementation is broken.

Then the fixes.
