### PR TITLE
HHVM (HipHop VM) current limits output to the first 255 bytes of output....

### DIFF
--- a/lib/PasswordLib/Random/Source/UniqID.php
+++ b/lib/PasswordLib/Random/Source/UniqID.php
@@ -52,9 +52,26 @@ class UniqID implements \PasswordLib\Random\Source {
      */
     public function generate($size) {
         $result = '';
-        while (strlen($result) < $size) {
-            $result = uniqid($result, true);
+
+        if(defined('HHVM_VERSION')) {
+
+        	while (strlen($result) < $size) {
+
+        			$result = $result . uniqid('', true);
+        	}
+
+        } else {
+
+	        while (strlen($result) < $size) {
+
+	        	if(defined('HHVM_VERSION')) {
+					$result = $result . uniqid('', true);
+	        	} else {
+	            	$result = uniqid($result, true);
+	        	}
+	        }
         }
+
         return substr($result, 0, $size);
     }
 


### PR DESCRIPTION
... If the prefix exceeds this, the returned string never contains

any added entropy, nor can it ever grow passed 255 bytes trapping us in an infinite loop if we request a larger string. Concatenating
the prefix and the generated should theoretically be faster through the uniqid function, so we'll only concatenate our own if we're
running HHVM, as well as have two seperate loops available so we only have to evalute if we're running HHVM once vs every iteration
of a singular loop.
